### PR TITLE
Fix for January in DBFs

### DIFF
--- a/src/structure.js
+++ b/src/structure.js
@@ -29,7 +29,7 @@ module.exports = function structure(data, meta) {
     view.setUint8(0, 0x03);
     // date of last update
     view.setUint8(1, now.getFullYear() - 1900);
-    view.setUint8(2, now.getMonth());
+    view.setUint8(2, now.getMonth() + 1); // DBF counts months from 1, not 0.
     view.setUint8(3, now.getDate());
     // number of records
     view.setUint32(4, data.length, true);


### PR DESCRIPTION
DBase uses bytes 1-3 for storing date of last update in YYMMDD format (see https://en.wikipedia.org/wiki/.dbf).
Currently all generated in January files are broken. Adding 1 to now.getMonth() fixes this issue.
