### PR TITLE
Field name length changes.

### DIFF
--- a/src/structure.js
+++ b/src/structure.js
@@ -48,7 +48,7 @@ module.exports = function structure(data, meta) {
 
     field_meta.forEach(function(f, i) {
         // field name
-        f.name.split('').slice(0, 8).forEach(function(c, x) {
+        f.name.split('').slice(0, 11).forEach(function(c, x) {
             view.setInt8(32 + i * 32 + x, c.charCodeAt(0));
         });
         // field type


### PR DESCRIPTION
Field name in dBASE prior v7 is 11 chars, not 8.
